### PR TITLE
chore(database): 未ビルド時でも`db:generate`および`db:migrate`が行えるように修正

### DIFF
--- a/packages/database/drizzle.config.ts
+++ b/packages/database/drizzle.config.ts
@@ -10,7 +10,7 @@ if (!process.env.DATABASE_URL) {
 export default defineConfig({
   dialect: 'postgresql',
   out: './drizzle',
-  schema: './dist/schema',
+  schema: './src/schema',
   dbCredentials: {
     url: process.env.DATABASE_URL,
   },


### PR DESCRIPTION
## 📝 説明

## 🔧 変更点
* `db:generate`および`db:migrate`実行時に使用するスキーマファイルを変更

## 💣 破壊的変更を含んでいますか？ (Yes/No)
No

## 🔍 関連Issue

## 📝 追加説明
