### PR TITLE
hotfix(dashboard): 特定のイベントログの送信先を設定できない問題を修正

### DIFF
--- a/apps/dashboard/src/app/(app)/guilds/[guildId]/event-log/forms/ban.tsx
+++ b/apps/dashboard/src/app/(app)/guilds/[guildId]/event-log/forms/ban.tsx
@@ -1,17 +1,17 @@
 ﻿'use client';
 
-import { FormChangePublisher } from '@/components/react-hook-form/change-publisher';
-import { ChannelSelect } from '@/components/react-hook-form/channel-select';
-import { FormDevTool } from '@/components/react-hook-form/devtool';
-import { ControlledForm } from '@/components/react-hook-form/ui/form';
-import { ControlledSwitch } from '@/components/react-hook-form/ui/switch';
-import { addToast } from '@heroui/react';
+import { addToast, Divider } from '@heroui/react';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { ChannelType } from 'discord-api-types/v10';
 import { useParams } from 'next/navigation';
 import { useContext, useEffect } from 'react';
 import { type SubmitHandler, useForm, useFormContext, useWatch } from 'react-hook-form';
 import type { z } from 'zod';
+import { ChannelSelect } from '@/components/react-hook-form/channel-select';
+import { FormDevTool } from '@/components/react-hook-form/devtool';
+import { FormSubmitButton } from '@/components/react-hook-form/submit-button';
+import { ControlledForm } from '@/components/react-hook-form/ui/form';
+import { ControlledSwitch } from '@/components/react-hook-form/ui/switch';
 import { updateSettingAction } from '../actions/ban';
 import { PropsContext } from '../form-container';
 import { settingFormSchema } from '../schemas/ban';
@@ -55,7 +55,8 @@ export function BanLogSettingForm({ setting, onFormChange }: Props) {
   return (
     <ControlledForm form={form} onSubmit={form.handleSubmit(onSubmit)} className='pb-0'>
       <GeneralSetting />
-      <FormChangePublisher />
+      <Divider />
+      <FormSubmitButton />
       <FormDevTool />
     </ControlledForm>
   );

--- a/apps/dashboard/src/app/(app)/guilds/[guildId]/event-log/forms/kick.tsx
+++ b/apps/dashboard/src/app/(app)/guilds/[guildId]/event-log/forms/kick.tsx
@@ -1,17 +1,17 @@
 ﻿'use client';
 
-import { FormChangePublisher } from '@/components/react-hook-form/change-publisher';
-import { ChannelSelect } from '@/components/react-hook-form/channel-select';
-import { FormDevTool } from '@/components/react-hook-form/devtool';
-import { ControlledForm } from '@/components/react-hook-form/ui/form';
-import { ControlledSwitch } from '@/components/react-hook-form/ui/switch';
-import { addToast } from '@heroui/react';
+import { addToast, Divider } from '@heroui/react';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { ChannelType } from 'discord-api-types/v10';
 import { useParams } from 'next/navigation';
 import { useContext, useEffect } from 'react';
 import { type SubmitHandler, useForm, useFormContext, useWatch } from 'react-hook-form';
 import type { z } from 'zod';
+import { ChannelSelect } from '@/components/react-hook-form/channel-select';
+import { FormDevTool } from '@/components/react-hook-form/devtool';
+import { FormSubmitButton } from '@/components/react-hook-form/submit-button';
+import { ControlledForm } from '@/components/react-hook-form/ui/form';
+import { ControlledSwitch } from '@/components/react-hook-form/ui/switch';
 import { updateSettingAction } from '../actions/kick';
 import { PropsContext } from '../form-container';
 import { settingFormSchema } from '../schemas/kick';
@@ -55,7 +55,8 @@ export function KickLogSettingForm({ setting, onFormChange }: Props) {
   return (
     <ControlledForm form={form} onSubmit={form.handleSubmit(onSubmit)} className='pb-0'>
       <GeneralSetting />
-      <FormChangePublisher />
+      <Divider />
+      <FormSubmitButton />
       <FormDevTool />
     </ControlledForm>
   );

--- a/apps/dashboard/src/app/(app)/guilds/[guildId]/event-log/forms/message-delete.tsx
+++ b/apps/dashboard/src/app/(app)/guilds/[guildId]/event-log/forms/message-delete.tsx
@@ -1,17 +1,17 @@
 ﻿'use client';
 
-import { FormChangePublisher } from '@/components/react-hook-form/change-publisher';
-import { ChannelSelect } from '@/components/react-hook-form/channel-select';
-import { FormDevTool } from '@/components/react-hook-form/devtool';
-import { ControlledForm } from '@/components/react-hook-form/ui/form';
-import { ControlledSwitch } from '@/components/react-hook-form/ui/switch';
-import { addToast } from '@heroui/react';
+import { addToast, Divider } from '@heroui/react';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { ChannelType } from 'discord-api-types/v10';
 import { useParams } from 'next/navigation';
 import { useContext, useEffect } from 'react';
 import { type SubmitHandler, useForm, useFormContext, useWatch } from 'react-hook-form';
 import type { z } from 'zod';
+import { ChannelSelect } from '@/components/react-hook-form/channel-select';
+import { FormDevTool } from '@/components/react-hook-form/devtool';
+import { FormSubmitButton } from '@/components/react-hook-form/submit-button';
+import { ControlledForm } from '@/components/react-hook-form/ui/form';
+import { ControlledSwitch } from '@/components/react-hook-form/ui/switch';
 import { updateSettingAction } from '../actions/message-delete';
 import { PropsContext } from '../form-container';
 import { settingFormSchema } from '../schemas/message-delete';
@@ -55,7 +55,8 @@ export function MsgDeleteLogSettingForm({ setting, onFormChange }: Props) {
   return (
     <ControlledForm form={form} onSubmit={form.handleSubmit(onSubmit)} className='pb-0'>
       <GeneralSetting />
-      <FormChangePublisher />
+      <Divider />
+      <FormSubmitButton />
       <FormDevTool />
     </ControlledForm>
   );

--- a/apps/dashboard/src/app/(app)/guilds/[guildId]/event-log/forms/message-edit.tsx
+++ b/apps/dashboard/src/app/(app)/guilds/[guildId]/event-log/forms/message-edit.tsx
@@ -1,17 +1,17 @@
 ﻿'use client';
 
-import { FormChangePublisher } from '@/components/react-hook-form/change-publisher';
-import { ChannelSelect } from '@/components/react-hook-form/channel-select';
-import { FormDevTool } from '@/components/react-hook-form/devtool';
-import { ControlledForm } from '@/components/react-hook-form/ui/form';
-import { ControlledSwitch } from '@/components/react-hook-form/ui/switch';
-import { addToast } from '@heroui/react';
+import { addToast, Divider } from '@heroui/react';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { ChannelType } from 'discord-api-types/v10';
 import { useParams } from 'next/navigation';
 import { useContext, useEffect } from 'react';
 import { type SubmitHandler, useForm, useFormContext, useWatch } from 'react-hook-form';
 import type { z } from 'zod';
+import { ChannelSelect } from '@/components/react-hook-form/channel-select';
+import { FormDevTool } from '@/components/react-hook-form/devtool';
+import { FormSubmitButton } from '@/components/react-hook-form/submit-button';
+import { ControlledForm } from '@/components/react-hook-form/ui/form';
+import { ControlledSwitch } from '@/components/react-hook-form/ui/switch';
 import { updateSettingAction } from '../actions/message-edit';
 import { PropsContext } from '../form-container';
 import { settingFormSchema } from '../schemas/message-edit';
@@ -55,7 +55,8 @@ export function MsgEditLogSettingForm({ setting, onFormChange }: Props) {
   return (
     <ControlledForm form={form} onSubmit={form.handleSubmit(onSubmit)} className='pb-0'>
       <GeneralSetting />
-      <FormChangePublisher />
+      <Divider />
+      <FormSubmitButton />
       <FormDevTool />
     </ControlledForm>
   );

--- a/apps/dashboard/src/app/(app)/guilds/[guildId]/event-log/forms/timeout.tsx
+++ b/apps/dashboard/src/app/(app)/guilds/[guildId]/event-log/forms/timeout.tsx
@@ -1,17 +1,17 @@
 ﻿'use client';
 
-import { FormChangePublisher } from '@/components/react-hook-form/change-publisher';
-import { ChannelSelect } from '@/components/react-hook-form/channel-select';
-import { FormDevTool } from '@/components/react-hook-form/devtool';
-import { ControlledForm } from '@/components/react-hook-form/ui/form';
-import { ControlledSwitch } from '@/components/react-hook-form/ui/switch';
-import { addToast } from '@heroui/react';
+import { addToast, Divider } from '@heroui/react';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { ChannelType } from 'discord-api-types/v10';
 import { useParams } from 'next/navigation';
 import { useContext, useEffect } from 'react';
 import { type SubmitHandler, useForm, useFormContext, useWatch } from 'react-hook-form';
 import type { z } from 'zod';
+import { ChannelSelect } from '@/components/react-hook-form/channel-select';
+import { FormDevTool } from '@/components/react-hook-form/devtool';
+import { FormSubmitButton } from '@/components/react-hook-form/submit-button';
+import { ControlledForm } from '@/components/react-hook-form/ui/form';
+import { ControlledSwitch } from '@/components/react-hook-form/ui/switch';
 import { updateSettingAction } from '../actions/timeout';
 import { PropsContext } from '../form-container';
 import { settingFormSchema } from '../schemas/timeout';
@@ -55,7 +55,8 @@ export function TimeoutLogSettingForm({ setting, onFormChange }: Props) {
   return (
     <ControlledForm form={form} onSubmit={form.handleSubmit(onSubmit)} className='pb-0'>
       <GeneralSetting />
-      <FormChangePublisher />
+      <Divider />
+      <FormSubmitButton />
       <FormDevTool />
     </ControlledForm>
   );

--- a/apps/dashboard/src/app/(app)/guilds/[guildId]/event-log/forms/voice.tsx
+++ b/apps/dashboard/src/app/(app)/guilds/[guildId]/event-log/forms/voice.tsx
@@ -1,17 +1,17 @@
 ﻿'use client';
 
-import { FormChangePublisher } from '@/components/react-hook-form/change-publisher';
-import { ChannelSelect } from '@/components/react-hook-form/channel-select';
-import { FormDevTool } from '@/components/react-hook-form/devtool';
-import { ControlledForm } from '@/components/react-hook-form/ui/form';
-import { ControlledSwitch } from '@/components/react-hook-form/ui/switch';
-import { addToast } from '@heroui/react';
+import { addToast, Divider } from '@heroui/react';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { ChannelType } from 'discord-api-types/v10';
 import { useParams } from 'next/navigation';
 import { useContext, useEffect } from 'react';
 import { type SubmitHandler, useForm, useFormContext, useWatch } from 'react-hook-form';
 import type { z } from 'zod';
+import { ChannelSelect } from '@/components/react-hook-form/channel-select';
+import { FormDevTool } from '@/components/react-hook-form/devtool';
+import { FormSubmitButton } from '@/components/react-hook-form/submit-button';
+import { ControlledForm } from '@/components/react-hook-form/ui/form';
+import { ControlledSwitch } from '@/components/react-hook-form/ui/switch';
 import { updateSettingAction } from '../actions/voice';
 import { PropsContext } from '../form-container';
 import { settingFormSchema } from '../schemas/voice';
@@ -55,7 +55,8 @@ export function VoiceLogSettingForm({ setting, onFormChange }: Props) {
   return (
     <ControlledForm form={form} onSubmit={form.handleSubmit(onSubmit)} className='pb-0'>
       <GeneralSetting />
-      <FormChangePublisher />
+      <Divider />
+      <FormSubmitButton />
       <FormDevTool />
     </ControlledForm>
   );

--- a/apps/dashboard/src/components/react-hook-form/submit-button.tsx
+++ b/apps/dashboard/src/components/react-hook-form/submit-button.tsx
@@ -1,0 +1,19 @@
+﻿import { Button } from '@heroui/react';
+import { useFormState } from 'react-hook-form';
+import { Icon } from '../icon';
+
+export function FormSubmitButton() {
+  const { isSubmitting, isDirty } = useFormState();
+
+  return (
+    <Button
+      type='submit'
+      color='primary'
+      isLoading={isSubmitting}
+      isDisabled={!isDirty}
+      startContent={!isSubmitting && <Icon icon='solar:diskette-bold' className='text-2xl' />}
+    >
+      変更を保存
+    </Button>
+  );
+}


### PR DESCRIPTION
## 📝 説明
* イベントログ内の設定を変更した際、「送信先チャンネル」用のSelectコンポーネントの前面に設定の保存バナーが表示され、チャンネルを設定することができなくなる問題を修正

## 🔧 変更点
* フォームの保存ボタンとしてFormSubmitButtonを追加
* フォーム内で使用する設定保存用のコンポーネントをFormChangePublisherからFormSubmitButtonに差し替え

## 💣 破壊的変更を含んでいますか？ (Yes/No)
No

## 🔍 関連Issue
fix #53

## 📝 追加説明
