### PR TITLE
feat: メンバー認証(画像)失敗時のエラーメッセージを追加

### DIFF
--- a/apps/bot/src/interactions/create/verify/_function.ts
+++ b/apps/bot/src/interactions/create/verify/_function.ts
@@ -85,7 +85,7 @@ export async function verifyForImageCaptcha(
         time: Duration.toMS('1m'),
       });
 
-      collector.on('collect', async (tryMessage) => {
+      collector.on('collect', (tryMessage) => {
         if (tryMessage.content !== text) {
           // 3回認証コードが異なっていた場合
           if (collector.collected.size === 3) {
@@ -101,17 +101,18 @@ export async function verifyForImageCaptcha(
           return interaction.user.send('`❌️` 認証コードが間違っています。');
         }
 
-        await interaction.member.roles
+        interaction.member.roles
           .add(roleId, '認証')
           .then(() => interaction.user.send(`${inlineCode('✅')} 認証に成功しました！`))
           .catch(() =>
             interaction.user.send(
               `${inlineCode('❌')} ロールを付与できませんでした。サーバーの管理者にご連絡ください`,
             ),
-          );
-
-        duringAuthentication.delete(interaction.user.id);
-        collector.stop();
+          )
+          .finally(() => {
+            duringAuthentication.delete(interaction.user.id);
+            collector.stop();
+          });
       });
     })
     .catch(() => {

--- a/apps/bot/src/interactions/create/verify/_function.ts
+++ b/apps/bot/src/interactions/create/verify/_function.ts
@@ -1,13 +1,13 @@
-﻿import { Captcha } from '@/modules/captcha';
-import { Duration } from '@/modules/format';
-import {
+﻿import {
   AttachmentBuilder,
   type ButtonInteraction,
   Colors,
   EmbedBuilder,
-  MessageFlags,
   inlineCode,
+  MessageFlags,
 } from 'discord.js';
+import { Captcha } from '@/modules/captcha';
+import { Duration } from '@/modules/format';
 
 const duringAuthentication = new Set<string>();
 
@@ -87,7 +87,8 @@ export async function verifyForImageCaptcha(
       });
 
       collector.on('collect', (tryMessage) => {
-        if (tryMessage.content !== text) return;
+        if (tryMessage.content !== text)
+          return interaction.user.send('`❌️` 認証コードが間違っています。');
 
         interaction.member.roles
           .add(roleId, '認証')


### PR DESCRIPTION
## 📝 説明
メンバー認証の画像認証について、以下の変更を追加
* 認証コードが誤っていた際、エラーメッセージを送信するように変更
* 3回目の入力で正しい認証コードを入力した際、成功時の動作と失敗時の動作どちらとも実行されていた問題を修正

## 💣 破壊的変更を含んでいますか？ (Yes/No)
No

## 🔍 関連Issue
close #59