### PR TITLE
hotfix: DockerHub上でBotとDashboardが同一のリポジトリに設定されていた問題を修正

### DIFF
--- a/.github/workflows/deploy-dashboard.yml
+++ b/.github/workflows/deploy-dashboard.yml
@@ -26,7 +26,7 @@ jobs:
           file: ./apps/dashboard/Dockerfile
           push: true
           tags: |
-            ${{ vars.DOCKERHUB_USERNAME }}/nonick-js_bot:latest 
+            ${{ vars.DOCKERHUB_USERNAME }}/nonick-js_dashboard:latest 
           platforms: linux/amd64
           build-args: |
             TURBO_TEAM=${{ vars.TURBO_TEAM }}


### PR DESCRIPTION
## 📝 説明
* `deploy-dashboard.yml`内に設定したDockerHubリポジトリ名を修正

## 💣 破壊的変更を含んでいますか？ (Yes/No)
No

## 🔍 関連Issue
