### PR TITLE
hotfix(dashboard): 特定条件下でタグ選択コンポーネントが使用できなくなる問題を修正

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/guilds/[guildId]/report/form.tsx
+++ b/apps/dashboard/src/app/(dashboard)/guilds/[guildId]/report/form.tsx
@@ -245,7 +245,7 @@ function ForumTagSettingField({ channels }: { channels: APIGuildChannel<GuildCha
       form.setValue('forumCompletedTag', null);
       form.setValue('forumIgnoredTag', null);
     }
-  }, [channel, form.formState.isDirty]);
+  }, [channel]);
 
   return (
     <Watch
@@ -274,7 +274,7 @@ function ForumTagSettingField({ channels }: { channels: APIGuildChannel<GuildCha
                   <ForumTagSelect
                     id={field.name}
                     aria-invalid={fieldState.invalid}
-                    className='sm:max-w-sm sm:min-w-sm'
+                    className='sm:max-w-xs sm:min-w-xs'
                     tags={tags}
                     value={field.value}
                     onValueChange={field.onChange}
@@ -297,7 +297,7 @@ function ForumTagSettingField({ channels }: { channels: APIGuildChannel<GuildCha
                   <ForumTagSelect
                     id={field.name}
                     aria-invalid={fieldState.invalid}
-                    className='sm:max-w-sm sm:min-w-sm'
+                    className='sm:max-w-xs sm:min-w-xs'
                     tags={tags}
                     value={field.value}
                     onValueChange={field.onChange}


### PR DESCRIPTION
## 📝 説明
サーバー内通報の設定ページで発生していた以下の問題を修正
* formの`isDirty`値の変化によってタグ選択コンポーネントの値がリセットされる問題
  * この問題により、特定条件下においてタグ選択コンポーネントの値を変更することができない問題が発生していた

## 💣 破壊的変更を含んでいますか？ (Yes/No)
No

## 🔍 関連Issue
