### PR TITLE
feat(bot): messageCreate時のGuildテーブルの更新処理を削除

### DIFF
--- a/apps/bot/src/events/bot/manageGuildModel.ts
+++ b/apps/bot/src/events/bot/manageGuildModel.ts
@@ -1,47 +1,21 @@
-import { db } from '@/modules/drizzle';
-import { DiscordEventBuilder } from '@/modules/events';
 import { guild } from '@repo/database';
 import { Events } from 'discord.js';
 import { eq } from 'drizzle-orm';
-
-const GuildCache = new Set<string>();
+import { db } from '@/modules/drizzle';
+import { DiscordEventBuilder } from '@/modules/events';
 
 const onGuildCreate = new DiscordEventBuilder({
   type: Events.GuildCreate,
-  async execute(guild) {
-    createGuild(guild.id);
-  },
-});
-
-const onMessageCreate = new DiscordEventBuilder({
-  type: Events.MessageCreate,
-  async execute(message) {
-    if (!message.inGuild()) return;
-    createGuild(message.guild.id);
+  async execute(apiGuild) {
+    await db.insert(guild).values({ id: apiGuild.id }).onConflictDoNothing();
   },
 });
 
 const onGuildDelete = new DiscordEventBuilder({
   type: Events.GuildDelete,
   async execute(apiGuild) {
-    db.delete(guild)
-      .where(eq(guild.id, apiGuild.id))
-      .then(() => {
-        GuildCache.delete(apiGuild.id);
-      });
+    await db.delete(guild).where(eq(guild.id, apiGuild.id));
   },
 });
 
-async function createGuild(guildId: string) {
-  const dbGuild = await db.query.guild.findFirst({
-    where: (setting, { eq }) => eq(setting.id, guildId),
-  });
-
-  if (GuildCache.has(guildId) || dbGuild) return;
-  await db
-    .insert(guild)
-    .values({ id: guildId })
-    .then(() => GuildCache.add(guildId));
-}
-
-export default [onGuildCreate, onMessageCreate, onGuildDelete];
+export default [onGuildCreate, onGuildDelete];


### PR DESCRIPTION
## 📝 説明
`messageCreate`イベント発火時に行っていたGuildテーブルの更新処理を削除し、Botの負荷軽減を行います。

## 💣 破壊的変更を含んでいますか？ (Yes/No)
No

## 🔍 関連Issue
